### PR TITLE
Fix image URL nullability issue

### DIFF
--- a/src/main/java/com/example/sns/post/entity/Post.java
+++ b/src/main/java/com/example/sns/post/entity/Post.java
@@ -27,7 +27,8 @@ public class Post {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false, name = "image_url")
+    // 이미지가 없는 게시물도 허용해야 하므로 nullable 설정을 제거한다
+    @Column(name = "image_url")
     private String imageUrl;
 
     @Column(nullable = false, updatable = false)


### PR DESCRIPTION
## Summary
- allow posts to have `null` image URLs

## Testing
- `gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_683fccfba9448327b31e7aab7630a403